### PR TITLE
fix broken pypi dist build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include COPYING.txt
+include gemelli/citations.bib

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To install the most up to date version of deicode, run the following command
 
 ## Using gemelli  inside [QIIME 2](https://qiime2.org/)
 
-A QIIME2 tutorial can be found [here](https://github.com/cameronmartino/gemelli/ipynb/tutorials/QIIME2-jansson-ibd-tutorial.md).
+A QIIME2 tutorial can be found [here](https://github.com/cameronmartino/gemelli/blob/master/ipynb/tutorials/QIIME2-jansson-ibd-tutorial.md).
 
 `Note: a more formal tutorial is coming soon.`
 

--- a/gemelli/__init__.py
+++ b/gemelli/__init__.py
@@ -6,4 +6,4 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"


### PR DESCRIPTION
This fixes issue #21 -- the MANIFEST.in was missing which caused the distribution build to miss the citations.bib file. This, in turn, caused the upload to pypi to break the QIIME plugin. 